### PR TITLE
Fix string equality check and missing ArrayIndexOutOfBoundsException

### DIFF
--- a/src/main/java/com/xamarin/jenkins/wrenchaggregator/Summary.java
+++ b/src/main/java/com/xamarin/jenkins/wrenchaggregator/Summary.java
@@ -145,7 +145,7 @@ public class Summary extends InvisibleAction {
     }
 
     public BadgeSummaryAction getAggregatorAction(Run target) {
-        return target.getActions(BadgeSummaryAction.class).stream().filter(action -> action.getIconPath() == "/userContent/jenkins-head.png" || action.getIconPath() == "warning.gif").findFirst().orElse(null);
+        return target.getActions(BadgeSummaryAction.class).stream().filter(action -> action.getIconPath().equals("/userContent/jenkins-head.png") || action.getIconPath().equals("warning.gif")).findFirst().orElse(null);
     }
 
     public ArrayList<String> getMatrixStepHeaders() {
@@ -263,7 +263,12 @@ public class Summary extends InvisibleAction {
         }
         result.append("</td>");
         try {
-            String rawStatus = getAggregatorAction(target).getText();
+            BadgeSummaryAction action = getAggregatorAction(target);
+            String rawStatus;
+            if (action == null) {
+                throw new ArrayIndexOutOfBoundsException();
+            }
+            rawStatus = action.getText();
             rawStatus = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + rawStatus.substring(rawStatus.indexOf("<table"));
             XPath xpath = XPathFactory.newInstance().newXPath();
             InputSource inputSource = new InputSource(new StringReader(rawStatus));


### PR DESCRIPTION
1) I fell into the Java vs. C# == trap, switched to .equals()
2) The code expected an ArrayIndexOutOfBoundsException for running/aborted builds which was no longer the case after switching to the filter() approach.